### PR TITLE
fix: unique suffix added to service account name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,13 +4,17 @@ locals {
   service_account_name = var.use_existing_service_account ? (
     var.service_account_name
     ) : (
-    length(var.service_account_name) > 0 ? var.service_account_name : "lacework-svc-account"
+    length(var.service_account_name) > 0 ? var.service_account_name : "lwsvc-${random_id.uniq.hex}"
   )
   service_account_json_key = jsondecode(var.use_existing_service_account ? (
     base64decode(var.service_account_private_key)
     ) : (
     base64decode(module.lacework_cfg_svc_account.private_key)
   ))
+}
+
+resource "random_id" "uniq" {
+  byte_length = 4
 }
 
 module "lacework_cfg_svc_account" {


### PR DESCRIPTION
Customers are experiencing the following problem:
```
Error: Error creating service account: googleapi: Error 409: Service account lacework-svc-account already exists within project projects/abc-demo-project-123., alreadyExists
```

This PR is adding a unique suffix to the default service account name.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>