### PR TITLE
ci: switch releases to be own by Lacework releng ⚡

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
       - checkout
       - add_ssh_keys:
           fingerprints:
-            - "33:a7:f7:c5:c8:f3:99:a7:b5:3d:05:02:35:a9:fa:e6"
+            - "9c:78:62:15:b5:93:aa:e7:98:4f:41:5d:63:a1:80:b9"
       - run: scripts/release.sh trigger
   release:
     executor: alpine

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -10,8 +10,8 @@ set -eou pipefail
 
 readonly org_name=lacework
 readonly project_name=terraform-gcp-config
-readonly git_user="Salim Afiune Maya"
-readonly git_email="afiune@lacework.net"
+readonly git_user="Lacework Inc."
+readonly git_email="ops+releng@lacework.net"
 VERSION=$(cat VERSION)
 
 usage() {


### PR DESCRIPTION
As a Lacework Engineer, 
I would like to use an in-house Github account to set up all releases and pipelines
So I don't have to use my personal Github account.

## Description
We are starting to use the company's Github account https://github.com/lacework-releng to do
our automated releases.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>