### PR TITLE
fix: mark sensitive output to support TF 0.14+

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -6,4 +6,5 @@ output "service_account_name" {
 output "service_account_private_key" {
   value       = length(var.service_account_private_key) > 0 ? var.service_account_private_key : module.lacework_cfg_svc_account.private_key
   description = "The private key in JSON format, base64 encoded"
+  sensitive   = true
 }


### PR DESCRIPTION
Support for Terraform 0.14+ and ALLY-452

Closes https://github.com/lacework/terraform-gcp-config/issues/11