### PR TITLE
fix: Add custom role with required get permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ roles/browser
 roles/iam.securityReviewer
 ```
 
+The following custom role is required depending on the integration level.
+`Lacework Compliance Role` or `Lacework Org Compliance Role`
+Both roles include the following permissions:
+```
+bigquery.datasets.get
+pubsub.topics.get
+storage.buckets.get
+```
+
 ## Required APIs
 ```
 iam.googleapis.com

--- a/main.tf
+++ b/main.tf
@@ -43,6 +43,21 @@ module "lacework_cfg_svc_account" {
 }
 
 // Roles for a PROJECT level integration
+resource "google_project_iam_custom_role" "lacework_custom_project_role" {
+  role_id     = "lwComplianceRole"
+  title       = "Lacework Compliance Role"
+  description = "Lacework Compliance Role"
+  permissions = ["bigquery.datasets.get", "pubsub.topics.get", "storage.buckets.get"]
+  create      = local.resource_level == "PROJECT"
+}
+
+resource "google_project_iam_member" "lacework_custom_project_role_binding" {
+  project    = local.project_id
+  role       = google_project_iam_custom_role.lacework_custom_project_role.name
+  member     = "serviceAccount:${local.service_account_json_key.client_email}"
+  depends_on = [google_project_iam_custom_role.lacework_custom_project_role]
+}
+
 resource "google_project_iam_member" "for_lacework_service_account" {
   for_each = toset(local.project_roles)
   project  = local.project_id
@@ -51,6 +66,22 @@ resource "google_project_iam_member" "for_lacework_service_account" {
 }
 
 // Roles for an ORGANIZATION level integration
+resource "google_organization_iam_custom_role" "lacework_custom_organization_role" {
+  role_id     = "lwOrgComplianceRole"
+  org_id      = var.organization_id
+  title       = "Lacework Org Compliance Role"
+  description = "Lacework Org Compliance Role"
+  permissions = ["bigquery.datasets.get", "pubsub.topics.get", "storage.buckets.get"]
+  create      = local.resource_level == "ORGANIZATION"
+}
+
+resource "google_organization_iam_member" "lacework_custom_organization_role_binding" {
+  org_id   = var.organization_id
+  role     = google_project_iam_custom_role.lacework_custom_project_role.name
+  member   = "serviceAccount:${local.service_account_json_key.client_email}"
+  depends_on = [google_organization_iam_custom_role.lacework_custom_organization_role]
+}
+
 resource "google_organization_iam_member" "for_lacework_service_account" {
   for_each = toset(local.organization_roles)
   org_id   = var.organization_id

--- a/main.tf
+++ b/main.tf
@@ -48,14 +48,15 @@ resource "google_project_iam_custom_role" "lacework_custom_project_role" {
   title       = "Lacework Compliance Role"
   description = "Lacework Compliance Role"
   permissions = ["bigquery.datasets.get", "pubsub.topics.get", "storage.buckets.get"]
-  create      = local.resource_level == "PROJECT"
+  count       = local.resource_level == "PROJECT" ? 1 : 0
 }
 
 resource "google_project_iam_member" "lacework_custom_project_role_binding" {
   project    = local.project_id
-  role       = google_project_iam_custom_role.lacework_custom_project_role.name
+  role       = google_project_iam_custom_role.lacework_custom_project_role.0.name
   member     = "serviceAccount:${local.service_account_json_key.client_email}"
   depends_on = [google_project_iam_custom_role.lacework_custom_project_role]
+  count      = local.resource_level == "PROJECT" ? 1 : 0
 }
 
 resource "google_project_iam_member" "for_lacework_service_account" {
@@ -72,14 +73,15 @@ resource "google_organization_iam_custom_role" "lacework_custom_organization_rol
   title       = "Lacework Org Compliance Role"
   description = "Lacework Org Compliance Role"
   permissions = ["bigquery.datasets.get", "pubsub.topics.get", "storage.buckets.get"]
-  create      = local.resource_level == "ORGANIZATION"
+  count       = local.resource_level == "ORGANIZATION" ? 1 : 0
 }
 
 resource "google_organization_iam_member" "lacework_custom_organization_role_binding" {
-  org_id   = var.organization_id
-  role     = google_project_iam_custom_role.lacework_custom_project_role.name
-  member   = "serviceAccount:${local.service_account_json_key.client_email}"
+  org_id     = var.organization_id
+  role       = google_project_iam_custom_role.lacework_custom_project_role.0.name
+  member     = "serviceAccount:${local.service_account_json_key.client_email}"
   depends_on = [google_organization_iam_custom_role.lacework_custom_organization_role]
+  count      = local.resource_level == "ORGANIZATION" ? 1 : 0
 }
 
 resource "google_organization_iam_member" "for_lacework_service_account" {

--- a/main.tf
+++ b/main.tf
@@ -78,7 +78,7 @@ resource "google_organization_iam_custom_role" "lacework_custom_organization_rol
 
 resource "google_organization_iam_member" "lacework_custom_organization_role_binding" {
   org_id     = var.organization_id
-  role       = google_project_iam_custom_role.lacework_custom_project_role.0.name
+  role       = google_organization_iam_custom_role.lacework_custom_organization_role.0.name
   member     = "serviceAccount:${local.service_account_json_key.client_email}"
   depends_on = [google_organization_iam_custom_role.lacework_custom_organization_role]
   count      = local.resource_level == "ORGANIZATION" ? 1 : 0


### PR DESCRIPTION
The missing permissions were uncovered after a bug fix on the GCP 2_2 checker. We have fixed API calls that were previously broken and they are now bubbling up these missing permission errors.

Signed-off-by: Ross Moles <ross.moles@lacework.net>