### PR TITLE
fix: Add missing compute.projects.get permission to custom role

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The following custom role is required depending on the integration level.
 Both roles include the following permissions:
 ```
 bigquery.datasets.get
+compute.projects.get
 pubsub.topics.get
 storage.buckets.get
 ```

--- a/main.tf
+++ b/main.tf
@@ -48,7 +48,7 @@ resource "google_project_iam_custom_role" "lacework_custom_project_role" {
   role_id     = "lwComplianceRole"
   title       = "Lacework Compliance Role"
   description = "Lacework Compliance Role"
-  permissions = ["bigquery.datasets.get", "pubsub.topics.get", "storage.buckets.get"]
+  permissions = ["bigquery.datasets.get", "compute.projects.get", "pubsub.topics.get", "storage.buckets.get"]
   count       = local.resource_level == "PROJECT" ? 1 : 0
 }
 


### PR DESCRIPTION
Adds missing compute.projects.get permission to custom role

Signed-off-by: Ross Moles <ross.moles@lacework.net>