### PR TITLE
feat: additional ServiceAccount permissions and roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ e.g. `terraform state rm 'google_project_iam_binding.for_lacework_service_accoun
 ```
 roles/browser
 roles/iam.securityReviewer
+roles/iam.serviceAccountTokenCreator
 ```
 
 The following custom role is required depending on the integration level.
@@ -30,6 +31,7 @@ bigquery.datasets.get
 compute.projects.get
 pubsub.topics.get
 storage.buckets.get
+compute.sslPolicies.get
 ```
 
 ## Required APIs

--- a/main.tf
+++ b/main.tf
@@ -14,11 +14,13 @@ locals {
   ))
   default_project_roles = [
     "roles/browser",
-    "roles/iam.securityReviewer"
+    "roles/iam.securityReviewer",
+    "roles/iam.serviceAccountTokenCreator
   ]
   default_organization_roles = [
     "roles/browser",
     "roles/iam.securityReviewer",
+    "roles/iam.serviceAccountTokenCreator",
   ]
   // if org_integration is false, project_roles = local.default_project_roles
   project_roles = var.org_integration ? [] : local.default_project_roles
@@ -48,9 +50,10 @@ resource "google_project_iam_custom_role" "lacework_custom_project_role" {
   role_id     = "lwComplianceRole_${random_id.uniq.hex}"
   title       = "Lacework Compliance Role"
   description = "Lacework Compliance Role"
-  permissions = ["bigquery.datasets.get", "compute.projects.get", "pubsub.topics.get", "storage.buckets.get"]
+  permissions = ["bigquery.datasets.get", "compute.projects.get", "pubsub.topics.get", "storage.buckets.get", "compute.sslPolicies.get"]
   count       = local.resource_level == "PROJECT" ? 1 : 0
 }
+
 
 resource "google_project_iam_member" "lacework_custom_project_role_binding" {
   project    = local.project_id
@@ -73,7 +76,7 @@ resource "google_organization_iam_custom_role" "lacework_custom_organization_rol
   org_id      = var.organization_id
   title       = "Lacework Org Compliance Role"
   description = "Lacework Org Compliance Role"
-  permissions = ["bigquery.datasets.get", "compute.projects.get", "pubsub.topics.get", "storage.buckets.get"]
+  permissions = ["bigquery.datasets.get", "compute.projects.get", "pubsub.topics.get", "storage.buckets.get", "compute.sslPolicies.get"]
   count       = local.resource_level == "ORGANIZATION" ? 1 : 0
 }
 

--- a/main.tf
+++ b/main.tf
@@ -15,12 +15,12 @@ locals {
   default_project_roles = [
     "roles/browser",
     "roles/iam.securityReviewer",
-    "roles/iam.serviceAccountTokenCreator
+    "roles/iam.serviceAccountTokenCreator"
   ]
   default_organization_roles = [
     "roles/browser",
     "roles/iam.securityReviewer",
-    "roles/iam.serviceAccountTokenCreator",
+    "roles/iam.serviceAccountTokenCreator"
   ]
   // if org_integration is false, project_roles = local.default_project_roles
   project_roles = var.org_integration ? [] : local.default_project_roles


### PR DESCRIPTION
Allow Org level and Project level integration ServiceAccount, additional roles
 and permissions to support Lacework Platform upcoming release with new report
 type, for Compliance analysis within GCP: CIS Security 1.2 Benchmark.
 https://workbench.cisecurity.org/benchmarks/5205

Signed-off-by: Declan Wilson <declan.wilson@lacework.net>