### PR TITLE
fix: remove iam.serviceAccountTokenCreator role from ServiceAccount

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ e.g. `terraform state rm 'google_project_iam_binding.for_lacework_service_accoun
 ```
 roles/browser
 roles/iam.securityReviewer
-roles/iam.serviceAccountTokenCreator
 ```
 
 The following custom role is required depending on the integration level.

--- a/main.tf
+++ b/main.tf
@@ -14,13 +14,11 @@ locals {
   ))
   default_project_roles = [
     "roles/browser",
-    "roles/iam.securityReviewer",
-    "roles/iam.serviceAccountTokenCreator"
+    "roles/iam.securityReviewer"
   ]
   default_organization_roles = [
     "roles/browser",
-    "roles/iam.securityReviewer",
-    "roles/iam.serviceAccountTokenCreator"
+    "roles/iam.securityReviewer"
   ]
   // if org_integration is false, project_roles = local.default_project_roles
   project_roles = var.org_integration ? [] : local.default_project_roles


### PR DESCRIPTION
---
name: Pull request template
about: 'fix: remove unneeded role from ServiceAccount '
---

***Issue***: Include link to the Jira/Github Issue
https://lacework.atlassian.net/browse/ALLY-678

Org level and Project level integration ServiceAccount, remove unneeded role
    errantly added to support Compliance analysis within GCP: CIS Security
    1.2 Benchmark.
    https://workbench.cisecurity.org/benchmarks/5205

Signed-off-by: Declan Wilson <declan.wilson@lacework.net>

***Description:***
Removed unneeded role

Org level and Project level integration ServiceAccount, remove unneeded role
    errantly added to support Compliance analysis within GCP: CIS Security
    1.2 Benchmark.
    https://workbench.cisecurity.org/benchmarks/5205

Signed-off-by: Declan Wilson <declan.wilson@lacework.net>

***Additional Info:***
Customers/Users should re-run this terraform module again; and then re-run a GCP orgnaization or project report ... they should not see any difference in their GCP Compliance reports from previous runs: 

GCP COMpliance Reports screen docs:
https://support.lacework.com/hc/en-us/articles/4406644935315-Understand-the-GCP-Compliance-Reports

