### PR TITLE
ci: fix pipeline by ignoring terraform.lock.hcl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Local .terraform directories
 **/.terraform/*
 
+# generated via "make ci"
+examples/**/.terraform.lock.hcl
+
 # .tfstate files
 *.tfstate
 *.tfstate.*


### PR DESCRIPTION
***Description:***
Add terraform.lock.hcl file to gitignore


