### PR TITLE
feat: Add 'roles/cloudasset.viewer' to GCP integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ e.g. `terraform state rm 'google_project_iam_binding.for_lacework_service_accoun
 ```
 roles/browser
 roles/iam.securityReviewer
+roles/cloudasset.viewer
 ```
 
 The following custom role is required depending on the integration level.
@@ -47,6 +48,7 @@ container.googleapis.com
 serviceusage.googleapis.com
 cloudresourcemanager.googleapis.com
 storage-component.googleapis.com
+cloudasset.googleapis.com
 ```
 
 ## Inputs

--- a/main.tf
+++ b/main.tf
@@ -14,11 +14,13 @@ locals {
   ))
   default_project_roles = [
     "roles/browser",
-    "roles/iam.securityReviewer"
+    "roles/iam.securityReviewer",
+    "roles/cloudasset.viewer"
   ]
   default_organization_roles = [
     "roles/browser",
-    "roles/iam.securityReviewer"
+    "roles/iam.securityReviewer",
+    "roles/cloudasset.viewer"
   ]
   // if org_integration is false, project_roles = local.default_project_roles
   project_roles = var.org_integration ? [] : local.default_project_roles

--- a/variables.tf
+++ b/variables.tf
@@ -42,18 +42,19 @@ variable "lacework_integration_name" {
 variable "required_config_apis" {
   type = map
   default = {
-    iam               = "iam.googleapis.com"
-    kms               = "cloudkms.googleapis.com"
-    dns               = "dns.googleapis.com"
-    pubsub            = "pubsub.googleapis.com"
-    compute           = "compute.googleapis.com"
-    logging           = "logging.googleapis.com"
-    bigquery          = "bigquery.googleapis.com"
-    sqladmin          = "sqladmin.googleapis.com"
-    containers        = "container.googleapis.com"
-    serviceusage      = "serviceusage.googleapis.com"
-    resourcemanager   = "cloudresourcemanager.googleapis.com"
-    storage_component = "storage-component.googleapis.com"
+    iam                  = "iam.googleapis.com"
+    kms                  = "cloudkms.googleapis.com"
+    dns                  = "dns.googleapis.com"
+    pubsub               = "pubsub.googleapis.com"
+    compute              = "compute.googleapis.com"
+    logging              = "logging.googleapis.com"
+    bigquery             = "bigquery.googleapis.com"
+    sqladmin             = "sqladmin.googleapis.com"
+    containers           = "container.googleapis.com"
+    serviceusage         = "serviceusage.googleapis.com"
+    resourcemanager      = "cloudresourcemanager.googleapis.com"
+    storage_component    = "storage-component.googleapis.com"
+    cloudasset_inventory = "cloudasset.googleapis.com"
   }
 }
 


### PR DESCRIPTION
---
name: ALLY-858 Add roles/cloudasset.viewer to GCP integrations
about: 'type(scope): Subject of the pull request '
---

***Issue***:

https://lacework.atlassian.net/browse/ALLY-858

***Description:***

In preparation for go-live of GCP resource management 2 (ingestion of GCP configuration data) we need access to cloud asset inventory. This code change adds the minimum access required (roles/cloudasset.viewer) to the GCP terraform.

***Additional Info:***


***Testing***

Created an integration using the TF on the main branch. Then changed to this branch and re-applied to verify that the new role is added as expected to the existing integration.
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with
the following symbols:
  + create

Terraform will perform the following actions:

  # google_project_iam_member.for_lacework_service_account["roles/cloudasset.viewer"] will be created
  + resource "google_project_iam_member" "for_lacework_service_account" {
      + etag    = (known after apply)
      + id      = (known after apply)
      + member  = (sensitive)
      + project = "lacework-ecosystem2"
      + role    = "roles/cloudasset.viewer"
    }

  # google_project_service.required_apis["cloudasset_inventory"] will be created
  + resource "google_project_service" "required_apis" {
      + disable_on_destroy = false
      + id                 = (known after apply)
      + project            = "lacework-ecosystem2"
      + service            = "cloudasset.googleapis.com"
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.
```

Also tested by using the SA credentials for the gcloud CLI and then running a CAI Gcloud command
```
➜  terraform-gcp-config git:(ALLY-858-gcp-cloudasset-viewer) ✗ gcloud auth activate-service-account lw-cfg-05c67d1b@lacework-ecosystem2.iam.gserviceaccount.com --key-file=/Users/rossmoles/Downloads/lacework-ecosystem2-7afa72ca6fab.json
Activated service account credentials for: [lw-cfg-05c67d1b@lacework-ecosystem2.iam.gserviceaccount.com]

➜  terraform-gcp-config git:(ALLY-858-gcp-cloudasset-viewer) ✗ gcloud asset list --project lacework-ecosystem2
---
ancestors:
- projects/133760594249
- folders/1022232695391
- organizations/294451184225
assetType: bigquery.googleapis.com/Dataset
name: //bigquery.googleapis.com/projects/lacework-ecosystem2/datasets/CMEK_encrypted_dataset
updateTime: '2021-08-17T08:12:55.532125Z'
---
ancestors:
- projects/133760594249
- folders/1022232695391
- organizations/294451184225
assetType: bigquery.googleapis.com/Dataset
name: //bigquery.googleapis.com/projects/lacework-ecosystem2/datasets/irwin_test
updateTime: '2021-07-26T09:40:09.516499Z'
....
```