### PR TITLE
feat: add folder exclusion logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # generated via "make ci"
 examples/**/.terraform.lock.hcl
+**/.terraform.lock.hcl
 
 # .tfstate files
 *.tfstate

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ cloudasset.googleapis.com
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.0.0, < 5.0.0 |
-| <a name="requirement_lacework"></a> [lacework](#requirement\_lacework) | ~> 0.15 |
+| <a name="requirement_lacework"></a> [lacework](#requirement\_lacework) | ~> 0.2 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | ~> 0.6 |
 
 ## Providers

--- a/README.md
+++ b/README.md
@@ -51,25 +51,71 @@ storage-component.googleapis.com
 cloudasset.googleapis.com
 ```
 
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.0.0, < 5.0.0 |
+| <a name="requirement_lacework"></a> [lacework](#requirement\_lacework) | ~> 0.15 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | ~> 0.6 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | 4.11.0 |
+| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | 0.15.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.1.0 |
+| <a name="provider_time"></a> [time](#provider\_time) | 0.7.2 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_lacework_cfg_svc_account"></a> [lacework\_cfg\_svc\_account](#module\_lacework\_cfg\_svc\_account) | lacework/service-account/gcp | ~> 1.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_folder_iam_member.for_lacework_service_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/folder_iam_member) | resource |
+| [google_organization_iam_custom_role.lacework_custom_organization_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_custom_role) | resource |
+| [google_organization_iam_member.for_lacework_service_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_member) | resource |
+| [google_organization_iam_member.lacework_custom_organization_role_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_member) | resource |
+| [google_project_iam_custom_role.lacework_custom_project_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
+| [google_project_iam_member.for_lacework_service_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.for_lacework_service_account_root_projects](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.lacework_custom_project_role_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_service.required_apis](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
+| [lacework_integration_gcp_cfg.default](https://registry.terraform.io/providers/lacework/lacework/latest/docs/resources/integration_gcp_cfg) | resource |
+| [random_id.uniq](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [time_sleep.wait_time](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
+| [google_folders.my-org-folders](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/folders) | data source |
+| [google_project.selected](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
+| [google_projects.my-org-projects](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/projects) | data source |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|----------|
-|org_integration|If set to true, configure an organization level integration|bool|false|false|
-|organization_id|The organization ID, required if org_integration is set to true|string|""|false|
-|project_id|A project ID different from the default defined inside the provider|string|""|false|
-|use_existing_service_account|Set this to true to use an existing Service Account. When using an existing service account, the required roles must be added manually.|bool|false|false|
-|service_account_name|The Service Account name (required when use_existing_service_account is set to true). This can also be used to specify the new service account name when use_existing_service_account is set to false|string|""|false|
-|service_account_private_key|The private key in JSON format, base64 encoded (required when use_existing_service_account is set to true)|string|""|false|
-|lacework_integration_name|The integration name displayed in the Lacework UI.|string|TF config|false|
-|required_config_apis|The APIs that should be enabled for this integration to be successful.|map|See the Required APIs section|false|
-|prefix|The prefix that will be used at the beginning of every generated resource|string|lw-cfg|false|
-|wait_time|Amount of time to wait before the next resource is provisioned.|string|10s|false|
-
+|------|-------------|------|---------|:--------:|
+| <a name="input_exclude_folders"></a> [exclude\_folders](#input\_exclude\_folders) | Enables logic to exclude a list of folders from the integration. Default is false | `bool` | `false` | no |
+| <a name="input_folders_to_exclude"></a> [folders\_to\_exclude](#input\_folders\_to\_exclude) | List of root folders to exclude if `exclude_folders` is set to `true`.  Format is 'folders/1234567890' | `set(string)` | `[]` | no |
+| <a name="input_include_root_projects"></a> [include\_root\_projects](#input\_include\_root\_projects) | Enables logic to include root-level projects if `exclude_folders` is set to `true`.  Default is true | `bool` | `true` | no |
+| <a name="input_lacework_integration_name"></a> [lacework\_integration\_name](#input\_lacework\_integration\_name) | n/a | `string` | `"TF config"` | no |
+| <a name="input_org_integration"></a> [org\_integration](#input\_org\_integration) | If set to true, configure an organization level integration | `bool` | `false` | no |
+| <a name="input_organization_id"></a> [organization\_id](#input\_organization\_id) | The organization ID, required if org\_integration is set to true | `string` | `""` | no |
+| <a name="input_prefix"></a> [prefix](#input\_prefix) | The prefix that will be use at the beginning of every generated resource | `string` | `"lw-cfg"` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | A project ID different from the default defined inside the provider | `string` | `""` | no |
+| <a name="input_required_config_apis"></a> [required\_config\_apis](#input\_required\_config\_apis) | n/a | `map(any)` | <pre>{<br>  "bigquery": "bigquery.googleapis.com",<br>  "cloudasset_inventory": "cloudasset.googleapis.com",<br>  "compute": "compute.googleapis.com",<br>  "containers": "container.googleapis.com",<br>  "dns": "dns.googleapis.com",<br>  "iam": "iam.googleapis.com",<br>  "kms": "cloudkms.googleapis.com",<br>  "logging": "logging.googleapis.com",<br>  "pubsub": "pubsub.googleapis.com",<br>  "resourcemanager": "cloudresourcemanager.googleapis.com",<br>  "serviceusage": "serviceusage.googleapis.com",<br>  "sqladmin": "sqladmin.googleapis.com",<br>  "storage_component": "storage-component.googleapis.com"<br>}</pre> | no |
+| <a name="input_service_account_name"></a> [service\_account\_name](#input\_service\_account\_name) | The Service Account name (required when use\_existing\_service\_account is set to true). This can also be used to specify the new service account name when use\_existing\_service\_account is set to false | `string` | `""` | no |
+| <a name="input_service_account_private_key"></a> [service\_account\_private\_key](#input\_service\_account\_private\_key) | The private key in JSON format, base64 encoded (required when use\_existing\_service\_account is set to true) | `string` | `""` | no |
+| <a name="input_use_existing_service_account"></a> [use\_existing\_service\_account](#input\_use\_existing\_service\_account) | Set this to true to use an existing Service Account | `bool` | `false` | no |
+| <a name="input_wait_time"></a> [wait\_time](#input\_wait\_time) | Amount of time to wait before the next resource is provisioned | `string` | `"10s"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-|service_account_name|The Service Account name|
-|service_account_private_key|The private key in JSON format, base64 encoded|
+| <a name="output_service_account_name"></a> [service\_account\_name](#output\_service\_account\_name) | The Service Account name |
+| <a name="output_service_account_private_key"></a> [service\_account\_private\_key](#output\_service\_account\_private\_key) | The private key in JSON format, base64 encoded |

--- a/examples/organization-level-config-exclude-folders/README.md
+++ b/examples/organization-level-config-exclude-folders/README.md
@@ -1,0 +1,53 @@
+# Integrate a Google Cloud Organization with Lacework for Configuration Assessment
+The following provides an example of integrating an entire Google Cloud Organization with Lacework for Cloud Resource configuration assessment.
+
+The fields required for this example are:
+
+| Name | Description | Type |
+|------|-------------|------|
+| `org_integration` | Set this to `true` to configure an organization level integration. | `bool` |
+| `organization_id` | The id of the GCP Organization to integrate with. | `string` |
+| `project_id` | The id of a Project, which will be used to deploy required resources for the integration. Note: if this is var is not explicitly set, the provider will check for the presence of the `GOOGLE_PROJECT` env var | `string` |
+| `exclude_folders` | Enables logic to exclude a list of folders from the integration. Default is false | `bool` |
+| `folders_to_exclude` | List of root folders to exclude if `exclude_folders` is set to `true`.  Format is 'folders/1234567890' | `set(string)` |
+
+
+```hcl
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}
+
+provider "google" {}
+
+provider "lacework" {}
+
+module "gcp_organization_level_config" {
+  source = "lacework/config/gcp"
+  version = "~> 1.0"
+  
+  # Set this integration to be created at the Organization level,
+  # a project id is needed since Lacework needs to deploy a few
+  # resources and those will be created in the provided project
+  # if no project_id is supplied, the project hosting the Service Account used to run the Terraform will be used
+  org_integration      = true
+  organization_id      = "my-organization-id"
+  project_id           = "abc-demo-project-123"
+  exclude_folders      = true
+  folders_to_exclude   = [
+    "folders/578370918314", 
+    "folders/1099205162015",
+  ] 
+}
+```
+
+Run Terraform:
+```
+$ terraform init
+$ GOOGLE_CREDENTIALS=account.json terraform apply
+```
+
+For detailed information on integrating Lacework with Google Cloud see [GCP Compliance and Audit Trail Integration - Terraform From Any Supported Host](https://support.lacework.com/hc/en-us/articles/360057065094-GCP-Compliance-and-Audit-Trail-Integration-Terraform-From-Any-Supported-Host)

--- a/examples/organization-level-config-exclude-folders/main.tf
+++ b/examples/organization-level-config-exclude-folders/main.tf
@@ -1,0 +1,19 @@
+provider "google" {}
+
+provider "lacework" {}
+
+module "gcp_organization_level_config" {
+  source = "../../"
+
+  # Set this integration to be created at the Organization level,
+  # a project id is needed since Lacework needs to deploy a few
+  # resources and those will be created in the provided project
+  org_integration      = true
+  organization_id      = "my-organization-id"
+  project_id           = "abc-demo-project-123"
+  exclude_folders      = true
+  folders_to_exclude   = [
+    "folders/578370918314", 
+    "folders/1099205162015",
+  ] 
+}

--- a/examples/organization-level-config-exclude-folders/versions.tf
+++ b/examples/organization-level-config-exclude-folders/versions.tf
@@ -1,0 +1,8 @@
+# required for Terraform 13
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -58,8 +58,8 @@ locals {
   root_project_roles = (var.org_integration && var.exclude_folders) ? (
     setproduct(local.root_projects[0][*], local.default_folder_roles)
     ) : (
-      []
-    )
+    []
+  )
 }
 
 resource "random_id" "uniq" {
@@ -148,10 +148,10 @@ resource "google_folder_iam_member" "for_lacework_service_account" {
 }
 
 resource "google_project_iam_member" "for_lacework_service_account_root_projects" {
-  count  = length(local.root_project_roles)
+  count   = length(local.root_project_roles)
   project = local.root_project_roles[count.index][0]
-  role   = local.root_project_roles[count.index][1]
-  member = "serviceAccount:${local.service_account_json_key.client_email}"
+  role    = local.root_project_roles[count.index][1]
+  member  = "serviceAccount:${local.service_account_json_key.client_email}"
 }
 
 resource "google_project_service" "required_apis" {

--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,41 @@ locals {
   // if org_integration is false, project_roles = local.default_project_roles
   project_roles = var.org_integration ? [] : local.default_project_roles
   // if org_integration is true, organization_roles = local.default_organization_roles
-  organization_roles = var.org_integration ? local.default_organization_roles : []
+  organization_roles = (var.org_integration && !var.exclude_folders) ? (
+    local.default_organization_roles
+    ) : (
+    (var.org_integration && var.exclude_folders) ? (
+      ["roles/resourcemanager.organizationViewer"]
+      ) : (
+      []
+    )
+  )
+  default_folder_roles = (var.org_integration && var.exclude_folders) ? (
+    [
+      "roles/browser",
+      "roles/iam.securityReviewer",
+      "roles/cloudasset.viewer",
+      google_organization_iam_custom_role.lacework_custom_organization_role.0.name
+    ]
+    ) : (
+    []
+  )
+  folders = [
+    (var.org_integration && var.exclude_folders) ? setsubtract(data.google_folders.my-org-folders[0].folders[*].name, var.folders_to_exclude) : toset([])
+  ]
+  root_projects = [
+    (var.org_integration && var.exclude_folders) ? toset(data.google_projects.my-org-projects[0].projects[*].project_id) : toset([])
+  ]
+  folder_roles = (var.org_integration && var.exclude_folders) ? (
+    setproduct(local.folders[0][*], local.default_folder_roles)
+    ) : (
+    []
+  )
+  root_project_roles = (var.org_integration && var.exclude_folders) ? (
+    setproduct(local.root_projects[0][*], local.default_folder_roles)
+    ) : (
+      []
+    )
 }
 
 resource "random_id" "uniq" {
@@ -71,6 +105,17 @@ resource "google_project_iam_member" "for_lacework_service_account" {
 }
 
 // Roles for an ORGANIZATION level integration
+
+data "google_folders" "my-org-folders" {
+  count     = (var.org_integration && var.exclude_folders) ? 1 : 0
+  parent_id = "organizations/${var.organization_id}"
+}
+
+data "google_projects" "my-org-projects" {
+  count  = (var.exclude_folders && var.include_root_projects) ? 1 : 0
+  filter = "parent.id=${var.organization_id}"
+}
+
 resource "google_organization_iam_custom_role" "lacework_custom_organization_role" {
   role_id     = "lwOrgComplianceRole_${random_id.uniq.hex}"
   org_id      = var.organization_id
@@ -85,7 +130,7 @@ resource "google_organization_iam_member" "lacework_custom_organization_role_bin
   role       = google_organization_iam_custom_role.lacework_custom_organization_role.0.name
   member     = "serviceAccount:${local.service_account_json_key.client_email}"
   depends_on = [google_organization_iam_custom_role.lacework_custom_organization_role]
-  count      = local.resource_level == "ORGANIZATION" ? 1 : 0
+  count      = (local.resource_level == "ORGANIZATION" && !var.exclude_folders) ? 1 : 0
 }
 
 resource "google_organization_iam_member" "for_lacework_service_account" {
@@ -93,6 +138,20 @@ resource "google_organization_iam_member" "for_lacework_service_account" {
   org_id   = var.organization_id
   role     = each.value
   member   = "serviceAccount:${local.service_account_json_key.client_email}"
+}
+
+resource "google_folder_iam_member" "for_lacework_service_account" {
+  count  = length(local.folder_roles)
+  folder = local.folder_roles[count.index][0]
+  role   = local.folder_roles[count.index][1]
+  member = "serviceAccount:${local.service_account_json_key.client_email}"
+}
+
+resource "google_project_iam_member" "for_lacework_service_account_root_projects" {
+  count  = length(local.root_project_roles)
+  project = local.root_project_roles[count.index][0]
+  role   = local.root_project_roles[count.index][1]
+  member = "serviceAccount:${local.service_account_json_key.client_email}"
 }
 
 resource "google_project_service" "required_apis" {

--- a/scripts/ci_tests.sh
+++ b/scripts/ci_tests.sh
@@ -12,6 +12,7 @@ TEST_CASES=(
   examples/environment-variables-project-level-config
   examples/existing-service-account-project-level-config
   examples/organization-level-config
+  examples/organization-level-config-exclude-folders
   examples/project-level-config
 )
 

--- a/variables.tf
+++ b/variables.tf
@@ -40,7 +40,7 @@ variable "lacework_integration_name" {
 }
 
 variable "required_config_apis" {
-  type = map
+  type = map(any)
   default = {
     iam                  = "iam.googleapis.com"
     kms                  = "cloudkms.googleapis.com"
@@ -68,4 +68,22 @@ variable "wait_time" {
   type        = string
   default     = "10s"
   description = "Amount of time to wait before the next resource is provisioned"
+}
+
+variable "exclude_folders" {
+  type        = bool
+  default     = false
+  description = "Enables logic to exclude a list of folders from the integration. Default is false"
+}
+
+variable "folders_to_exclude" {
+  type        = set(string)
+  default     = []
+  description = "List of root folders to exclude if `exclude_folders` is set to `true`.  Format is 'folders/1234567890'"
+}
+
+variable "include_root_projects" {
+  type        = bool
+  default     = true
+  description = "Enables logic to include root-level projects if `exclude_folders` is set to `true`.  Default is true"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
     time   = "~> 0.6"
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.15"
+      version = "~> 0.2"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
     time   = "~> 0.6"
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.2"
+      version = "~> 0.15"
     }
   }
 }


### PR DESCRIPTION
***Issue***: As a customer, I would like to exclude certain folders from my Lacework integration

***Description:***
This is a first pass at adding folder-level exclusions into our terraform logic.  This will address customer requests to exclude things like the `system-gsuite` folders that can grow into a large amount of folders with no cloud resources, leading to a suboptimal UI experience within Lacework.

As an initial release, this code only handles exclusions of root-level folders; it will not consider subfolders below the root of the GCP organization.  It also introduces a flag `include_root_projects` that defaults to `true` - this can be set to `false` if the customer does not want to include the projects that may be located in the root of the organization.

***Additional Info:***
This is coordinating with https://github.com/lacework/terraform-gcp-audit-log/pull/49

Changes that may impact other parts of the code:
- Any logic that checks for `var.org_integration` now checks for the status of `var.exclude_folders` as well

Testing has been performed against:
- Org-level integration with no exclusions
- Org-level integration with multiple exclusions
- Project-level integration


