### PR TITLE
ci: user a variable to inject organization_id

### DIFF
--- a/examples/organization-level-config-exclude-folders/main.tf
+++ b/examples/organization-level-config-exclude-folders/main.tf
@@ -8,12 +8,16 @@ module "gcp_organization_level_config" {
   # Set this integration to be created at the Organization level,
   # a project id is needed since Lacework needs to deploy a few
   # resources and those will be created in the provided project
-  org_integration      = true
-  organization_id      = "my-organization-id"
-  project_id           = "abc-demo-project-123"
-  exclude_folders      = true
-  folders_to_exclude   = [
-    "folders/578370918314", 
+  org_integration = true
+  organization_id = var.organization_id
+  project_id      = "abc-demo-project-123"
+  exclude_folders = true
+  folders_to_exclude = [
+    "folders/578370918314",
     "folders/1099205162015",
-  ] 
+  ]
+}
+
+variable "organization_id" {
+  default = "my-organization-id"
 }

--- a/examples/organization-level-config/main.tf
+++ b/examples/organization-level-config/main.tf
@@ -9,6 +9,10 @@ module "gcp_organization_level_config" {
   # a project id is needed since Lacework needs to deploy a few
   # resources and those will be created in the provided project
   org_integration = true
-  organization_id = "my-organization-id"
+  organization_id = var.organization_id
   project_id      = "abc-demo-project-123"
+}
+
+variable "organization_id" {
+  default = "my-organization-id"
 }


### PR DESCRIPTION

## Summary

The new folder exclusion feature needs an actual organization id to be injected for our automated tests.

## How did you test this change?

The pipeline is broken at the moment, we should have a clean build now.

## Issue

N/A
