### PR TITLE
feat(api): Enable api essentialcontacts.googleapis.com api

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ serviceusage.googleapis.com
 cloudresourcemanager.googleapis.com
 storage-component.googleapis.com
 cloudasset.googleapis.com
+essentialcontacts.googleapis.com
 ```
 
 ## Requirements
@@ -107,7 +108,7 @@ cloudasset.googleapis.com
 | <a name="input_organization_id"></a> [organization\_id](#input\_organization\_id) | The organization ID, required if org\_integration is set to true | `string` | `""` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | The prefix that will be use at the beginning of every generated resource | `string` | `"lw-cfg"` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | A project ID different from the default defined inside the provider | `string` | `""` | no |
-| <a name="input_required_config_apis"></a> [required\_config\_apis](#input\_required\_config\_apis) | n/a | `map(any)` | <pre>{<br>  "bigquery": "bigquery.googleapis.com",<br>  "cloudasset_inventory": "cloudasset.googleapis.com",<br>  "compute": "compute.googleapis.com",<br>  "containers": "container.googleapis.com",<br>  "dns": "dns.googleapis.com",<br>  "iam": "iam.googleapis.com",<br>  "kms": "cloudkms.googleapis.com",<br>  "logging": "logging.googleapis.com",<br>  "pubsub": "pubsub.googleapis.com",<br>  "resourcemanager": "cloudresourcemanager.googleapis.com",<br>  "serviceusage": "serviceusage.googleapis.com",<br>  "sqladmin": "sqladmin.googleapis.com",<br>  "storage_component": "storage-component.googleapis.com"<br>}</pre> | no |
+| <a name="input_required_config_apis"></a> [required\_config\_apis](#input\_required\_config\_apis) | n/a | `map(any)` | <pre>{<br>  "bigquery": "bigquery.googleapis.com",<br>  "cloudasset_inventory": "cloudasset.googleapis.com",<br>  "compute": "compute.googleapis.com",<br>  "containers": "container.googleapis.com",<br>  "dns": "dns.googleapis.com",<br>  "essentialcontacts": "essentialcontacts.googleapis.com",<br>  "iam": "iam.googleapis.com",<br>  "kms": "cloudkms.googleapis.com",<br>  "logging": "logging.googleapis.com",<br>  "pubsub": "pubsub.googleapis.com",<br>  "resourcemanager": "cloudresourcemanager.googleapis.com",<br>  "serviceusage": "serviceusage.googleapis.com",<br>  "sqladmin": "sqladmin.googleapis.com",<br>  "storage_component": "storage-component.googleapis.com"<br>}</pre> | no |
 | <a name="input_service_account_name"></a> [service\_account\_name](#input\_service\_account\_name) | The Service Account name (required when use\_existing\_service\_account is set to true). This can also be used to specify the new service account name when use\_existing\_service\_account is set to false | `string` | `""` | no |
 | <a name="input_service_account_private_key"></a> [service\_account\_private\_key](#input\_service\_account\_private\_key) | The private key in JSON format, base64 encoded (required when use\_existing\_service\_account is set to true) | `string` | `""` | no |
 | <a name="input_use_existing_service_account"></a> [use\_existing\_service\_account](#input\_use\_existing\_service\_account) | Set this to true to use an existing Service Account | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ essentialcontacts.googleapis.com
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 4.28.0 |
-| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | 0.21.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.3.2 |
-| <a name="provider_time"></a> [time](#provider\_time) | 0.7.2 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 4.4.0, < 5.0.0 |
+| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | ~> 0.2 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_time"></a> [time](#provider\_time) | ~> 0.6 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ essentialcontacts.googleapis.com
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 4.4.0, < 5.0.0 |
-| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | ~> 0.2 |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
-| <a name="provider_time"></a> [time](#provider\_time) | ~> 0.6 |
+| <a name="provider_google"></a> [google](#provider\_google) | 4.28.0 |
+| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | 0.21.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.3.2 |
+| <a name="provider_time"></a> [time](#provider\_time) | 0.7.2 |
 
 ## Modules
 

--- a/variables.tf
+++ b/variables.tf
@@ -59,6 +59,7 @@ variable "required_config_apis" {
     resourcemanager      = "cloudresourcemanager.googleapis.com"
     storage_component    = "storage-component.googleapis.com"
     cloudasset_inventory = "cloudasset.googleapis.com"
+    essentialcontacts    = "essentialcontacts.googleapis.com"
   }
 }
 


### PR DESCRIPTION
feat(api): Update README and required_config_apis map to include essentialcontacts.googleapis.com api

## Summary

To collect GCP essential contacts configuration data, we need the project to which the service account belongs to have the essential contacts API enabled.
This changes adds this functionality to the terraform code and updates the README.


## How did you test this change?

Please see test notes on the JIRA [RAIN-34137](https://lacework.atlassian.net/browse/RAIN-34137)

## Issue

[RAIN-34137](https://lacework.atlassian.net/browse/RAIN-34137)