### PR TITLE
feat: adding folder inclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ cloudasset.googleapis.com
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 4.11.0 |
-| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | 0.15.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.1.0 |
-| <a name="provider_time"></a> [time](#provider\_time) | 0.7.2 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 4.4.0, < 5.0.0 |
+| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | ~> 0.2 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_time"></a> [time](#provider\_time) | ~> 0.6 |
 
 ## Modules
 
@@ -100,6 +100,7 @@ cloudasset.googleapis.com
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_folders_to_exclude"></a> [folders\_to\_exclude](#input\_folders\_to\_exclude) | List of root folders to exclude in an organization-level integration.  Format is 'folders/1234567890' | `set(string)` | `[]` | no |
+| <a name="input_folders_to_include"></a> [folders\_to\_include](#input\_folders\_to\_include) | List of root folders to include in an organization-level integration.  Format is 'folders/1234567890' | `set(string)` | `[]` | no |
 | <a name="input_include_root_projects"></a> [include\_root\_projects](#input\_include\_root\_projects) | Enables logic to include root-level projects if excluding folders.  Default is true | `bool` | `true` | no |
 | <a name="input_lacework_integration_name"></a> [lacework\_integration\_name](#input\_lacework\_integration\_name) | n/a | `string` | `"TF config"` | no |
 | <a name="input_org_integration"></a> [org\_integration](#input\_org\_integration) | If set to true, configure an organization level integration | `bool` | `false` | no |

--- a/examples/organization-level-config-exclude-folders/README.md
+++ b/examples/organization-level-config-exclude-folders/README.md
@@ -1,5 +1,5 @@
-# Integrate a Google Cloud Organization with Lacework for Configuration Assessment
-The following provides an example of integrating an entire Google Cloud Organization with Lacework for Cloud Resource configuration assessment.
+# Integrate a Google Cloud Organization with Lacework for Configuration Assessment (Folder Exclusion)
+The following provides an example of integrating a Google Cloud Organization with Lacework for Cloud Resource configuration assessment, excluding specific folders.
 
 The fields required for this example are:
 

--- a/examples/organization-level-config-exclude-folders/README.md
+++ b/examples/organization-level-config-exclude-folders/README.md
@@ -1,4 +1,4 @@
-# Integrate a Google Cloud Organization with Lacework for Configuration Assessment (Folder Exclusion)
+# Integrate a Google Cloud Organization with Lacework for Configuration Assessment Excluding Folder(s)
 The following provides an example of integrating a Google Cloud Organization with Lacework for Cloud Resource configuration assessment, excluding specific folders.
 
 The fields required for this example are:
@@ -48,4 +48,4 @@ $ terraform init
 $ GOOGLE_CREDENTIALS=account.json terraform apply
 ```
 
-For detailed information on integrating Lacework with Google Cloud see [GCP Compliance and Audit Trail Integration - Terraform From Any Supported Host](https://docs.lacework.com/gcp-compliance-and-audit-log-integration-terraform-from-any-supported-host)
+For detailed information on integrating Lacework with Google Cloud see [GCP Compliance and Audit Trail Integration - Terraform From Any Supported Host](https://docs.lacework.com/onboarding/gcp-compliance-and-audit-log-integration-terraform-from-any-supported-host)

--- a/examples/organization-level-config-exclude-folders/main.tf
+++ b/examples/organization-level-config-exclude-folders/main.tf
@@ -11,6 +11,7 @@ module "gcp_organization_level_config" {
   org_integration = true
   organization_id = var.organization_id
   project_id      = "abc-demo-project-123"
+
   folders_to_exclude = [
     "folders/578370918314",
     "folders/1099205162015",

--- a/examples/organization-level-config-include-folders/README.md
+++ b/examples/organization-level-config-include-folders/README.md
@@ -1,4 +1,4 @@
-# Integrate a Google Cloud Organization with Lacework for Configuration Assessment [Specific Folder(s)]
+# Integrate Google Cloud Folders with Lacework at the Organization level
 The following provides an example of integrating a Google Cloud Organization with Lacework for Cloud Resource configuration assessment, targeting specific folders.
 
 The fields required for this example are:
@@ -24,6 +24,8 @@ provider "google" {}
 provider "lacework" {}
 
 module "gcp_organization_level_config" {
+  source          = "lacework/config/gcp"
+  version         = "~> 2.2"
   org_integration = true
   organization_id = var.organization_id
   project_id      = "abc-demo-project-123"
@@ -35,5 +37,5 @@ module "gcp_organization_level_config" {
 }
 ```
 
-For detailed information on integrating Lacework with Google Cloud see [GCP Compliance and Audit Trail Integration - Terraform From Any Supported Host](https://docs.lacework.com/gcp-compliance-and-audit-log-integration-terraform-from-any-supported-host)
+For detailed information on integrating Lacework with Google Cloud see [GCP Compliance and Audit Trail Integration - Terraform From Any Supported Host](https://docs.lacework.com/onboarding/gcp-compliance-and-audit-log-integration-terraform-from-any-supported-host)
 

--- a/examples/organization-level-config-include-folders/README.md
+++ b/examples/organization-level-config-include-folders/README.md
@@ -1,0 +1,39 @@
+# Integrate a Google Cloud Organization with Lacework for Configuration Assessment [Specific Folder(s)]
+The following provides an example of integrating a Google Cloud Organization with Lacework for Cloud Resource configuration assessment, targeting specific folders.
+
+The fields required for this example are:
+
+| Name | Description | Type |
+|------|-------------|------|
+| `org_integration` | Set this to `true` to configure an organization level integration. | `bool` |
+| `organization_id` | The id of the GCP Organization to integrate with. | `string` |
+| `project_id` | The id of a Project, which will be used to deploy required resources for the integration. Note: if this is var is not explicitly set, the provider will check for the presence of the `GOOGLE_PROJECT` env var | `string` |
+| `folders_to_include` | List of root folders to specifically include in an organization-level integration (All other root folders and projects will be excluded).  Format is 'folders/1234567890' | `set(string)` |
+
+```hcl
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}
+
+provider "google" {}
+
+provider "lacework" {}
+
+module "gcp_organization_level_config" {
+  org_integration = true
+  organization_id = var.organization_id
+  project_id      = "abc-demo-project-123"
+  
+  folders_to_include = [
+    "folders/123456789012",
+    "folders/345678901234"
+  ]
+}
+```
+
+For detailed information on integrating Lacework with Google Cloud see [GCP Compliance and Audit Trail Integration - Terraform From Any Supported Host](https://docs.lacework.com/gcp-compliance-and-audit-log-integration-terraform-from-any-supported-host)
+

--- a/examples/organization-level-config-include-folders/main.tf
+++ b/examples/organization-level-config-include-folders/main.tf
@@ -2,17 +2,22 @@ provider "google" {}
 
 provider "lacework" {}
 
-variable "organization_id" {
-  default = "my-organization-id"
-}
-
 module "gcp_organization_level_config" {
+  source = "../../"
+
+  # Set this integration to be created at the Organization level,
+  # a project id is needed since Lacework needs to deploy a few
+  # resources and those will be created in the provided project
   org_integration = true
   organization_id = var.organization_id
   project_id      = "abc-demo-project-123"
-  
+
   folders_to_include = [
     "folders/123456789012",
     "folders/345678901234"
   ]
+}
+
+variable "organization_id" {
+  default = "my-organization-id"
 }

--- a/examples/organization-level-config-include-folders/main.tf
+++ b/examples/organization-level-config-include-folders/main.tf
@@ -1,0 +1,18 @@
+provider "google" {}
+
+provider "lacework" {}
+
+variable "organization_id" {
+  default = "my-organization-id"
+}
+
+module "gcp_organization_level_config" {
+  org_integration = true
+  organization_id = var.organization_id
+  project_id      = "abc-demo-project-123"
+  
+  folders_to_include = [
+    "folders/123456789012",
+    "folders/345678901234"
+  ]
+}

--- a/examples/organization-level-config-include-folders/versions.tf
+++ b/examples/organization-level-config-include-folders/versions.tf
@@ -1,0 +1,9 @@
+# required for Terraform 13
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}
+

--- a/main.tf
+++ b/main.tf
@@ -2,40 +2,49 @@ locals {
   resource_level = var.org_integration ? "ORGANIZATION" : "PROJECT"
   resource_id    = var.org_integration ? var.organization_id : module.lacework_cfg_svc_account.project_id
   project_id     = data.google_project.selected.project_id
+
   exclude_folders = length(var.folders_to_exclude) != 0
+  explicit_folders = length(var.folders_to_include) != 0
+
   service_account_name = var.use_existing_service_account ? (
     var.service_account_name
     ) : (
     length(var.service_account_name) > 0 ? var.service_account_name : "${var.prefix}-${random_id.uniq.hex}"
   )
+  
   service_account_json_key = jsondecode(var.use_existing_service_account ? (
     base64decode(var.service_account_private_key)
     ) : (
     base64decode(module.lacework_cfg_svc_account.private_key)
   ))
+  
   default_project_roles = [
     "roles/browser",
     "roles/iam.securityReviewer",
     "roles/cloudasset.viewer"
   ]
+  
   default_organization_roles = [
     "roles/browser",
     "roles/iam.securityReviewer",
     "roles/cloudasset.viewer"
   ]
+  
   // if org_integration is false, project_roles = local.default_project_roles
   project_roles = var.org_integration ? [] : local.default_project_roles
+  
   // if org_integration is true, organization_roles = local.default_organization_roles
-  organization_roles = (var.org_integration && !local.exclude_folders) ? (
+  organization_roles = (var.org_integration && !(local.exclude_folders || local.explicit_folders)) ? (
     local.default_organization_roles
     ) : (
-    (var.org_integration && local.exclude_folders) ? (
+    (var.org_integration && (local.exclude_folders || local.explicit_folders)) ? (
       ["roles/resourcemanager.organizationViewer"]
       ) : (
       []
     )
   )
-  default_folder_roles = (var.org_integration && local.exclude_folders) ? (
+  
+  default_folder_roles = (var.org_integration && (local.exclude_folders || local.explicit_folders)) ? (
     [
       "roles/browser",
       "roles/iam.securityReviewer",
@@ -45,17 +54,27 @@ locals {
     ) : (
     []
   )
+  
   folders = [
-    (var.org_integration && local.exclude_folders) ? setsubtract(data.google_folders.my-org-folders[0].folders[*].name, var.folders_to_exclude) : toset([])
-  ]
+    (var.org_integration && local.exclude_folders) ? (
+      setsubtract(data.google_folders.my-org-folders[0].folders[*].name, var.folders_to_exclude)
+    ) : (
+      var.org_integration && local.explicit_folders) ? (
+        var.folders_to_include
+      ) : (
+        toset([])
+      ) ]
+  
   root_projects = [
     (var.org_integration && local.exclude_folders && var.include_root_projects) ? toset(data.google_projects.my-org-projects[0].projects[*].project_id) : toset([])
   ]
-  folder_roles = (var.org_integration && local.exclude_folders) ? (
+  
+  folder_roles = (var.org_integration && (local.exclude_folders || local.explicit_folders)) ? (
     setproduct(local.folders[0][*], local.default_folder_roles)
     ) : (
     []
   )
+  
   root_project_roles = (var.org_integration && var.include_root_projects) ? (
     setproduct(local.root_projects[0][*], local.default_folder_roles)
     ) : (
@@ -131,7 +150,7 @@ resource "google_organization_iam_member" "lacework_custom_organization_role_bin
   role       = google_organization_iam_custom_role.lacework_custom_organization_role.0.name
   member     = "serviceAccount:${local.service_account_json_key.client_email}"
   depends_on = [google_organization_iam_custom_role.lacework_custom_organization_role]
-  count      = (local.resource_level == "ORGANIZATION" && !local.exclude_folders) ? 1 : 0
+  count      = (local.resource_level == "ORGANIZATION" && !(local.exclude_folders || local.explicit_folders)) ? 1 : 0
 }
 
 resource "google_organization_iam_member" "for_lacework_service_account" {

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ locals {
   resource_id    = var.org_integration ? var.organization_id : module.lacework_cfg_svc_account.project_id
   project_id     = data.google_project.selected.project_id
 
-  exclude_folders = length(var.folders_to_exclude) != 0
+  exclude_folders  = length(var.folders_to_exclude) != 0
   explicit_folders = length(var.folders_to_include) != 0
 
   service_account_name = var.use_existing_service_account ? (
@@ -11,28 +11,28 @@ locals {
     ) : (
     length(var.service_account_name) > 0 ? var.service_account_name : "${var.prefix}-${random_id.uniq.hex}"
   )
-  
+
   service_account_json_key = jsondecode(var.use_existing_service_account ? (
     base64decode(var.service_account_private_key)
     ) : (
     base64decode(module.lacework_cfg_svc_account.private_key)
   ))
-  
+
   default_project_roles = [
     "roles/browser",
     "roles/iam.securityReviewer",
     "roles/cloudasset.viewer"
   ]
-  
+
   default_organization_roles = [
     "roles/browser",
     "roles/iam.securityReviewer",
     "roles/cloudasset.viewer"
   ]
-  
+
   // if org_integration is false, project_roles = local.default_project_roles
   project_roles = var.org_integration ? [] : local.default_project_roles
-  
+
   // if org_integration is true, organization_roles = local.default_organization_roles
   organization_roles = (var.org_integration && !(local.exclude_folders || local.explicit_folders)) ? (
     local.default_organization_roles
@@ -43,7 +43,7 @@ locals {
       []
     )
   )
-  
+
   default_folder_roles = (var.org_integration && (local.exclude_folders || local.explicit_folders)) ? (
     [
       "roles/browser",
@@ -54,27 +54,27 @@ locals {
     ) : (
     []
   )
-  
+
   folders = [
     (var.org_integration && local.exclude_folders) ? (
       setsubtract(data.google_folders.my-org-folders[0].folders[*].name, var.folders_to_exclude)
-    ) : (
-      var.org_integration && local.explicit_folders) ? (
-        var.folders_to_include
       ) : (
-        toset([])
-      ) ]
-  
+      var.org_integration && local.explicit_folders) ? (
+      var.folders_to_include
+      ) : (
+      toset([])
+  )]
+
   root_projects = [
     (var.org_integration && local.exclude_folders && var.include_root_projects) ? toset(data.google_projects.my-org-projects[0].projects[*].project_id) : toset([])
   ]
-  
+
   folder_roles = (var.org_integration && (local.exclude_folders || local.explicit_folders)) ? (
     setproduct(local.folders[0][*], local.default_folder_roles)
     ) : (
     []
   )
-  
+
   root_project_roles = (var.org_integration && var.include_root_projects) ? (
     setproduct(local.root_projects[0][*], local.default_folder_roles)
     ) : (

--- a/scripts/ci_tests.sh
+++ b/scripts/ci_tests.sh
@@ -13,6 +13,7 @@ TEST_CASES=(
   examples/existing-service-account-project-level-config
   examples/organization-level-config
   examples/organization-level-config-exclude-folders
+  examples/organization-level-config-include-folders
   examples/project-level-config
 )
 

--- a/variables.tf
+++ b/variables.tf
@@ -85,3 +85,9 @@ variable "include_root_projects" {
   default     = true
   description = "Enables logic to include root-level projects if excluding folders.  Default is true"
 }
+
+variable "folders_to_include" {
+  type        = set(string)
+  default     = []
+  description = "List of root folders to include in an organization-level integration.  Format is 'folders/1234567890'"
+}


### PR DESCRIPTION
## Summary

This PR adds logic to specify a set of folders to specifically target for a Lacework integration, where customers may not want to include an entire Organization for a particular integration.

## How did you test this change?

This integration has been tested against a single organization targeting a single folder, and later adding an additional folder.

## Issue

[ALLY-837](https://lacework.atlassian.net/browse/ALLY-837)
