### PR TITLE
fix(variable): project id regex to match constraint

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -15,8 +15,8 @@ variable "project_id" {
   default     = ""
   description = "A project ID different from the default defined inside the provider"
   validation {
-    condition     = can(regex("(^[a-z][a-z0-9_-]{6,30}[^-]$|^$)", var.project_id))
-    error_message = "The project_id variable must be a valid GCP project ID. It must be 6 to 30 lowercase ASCII letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited.. Example: tokyo-rain-123."
+    condition     = can(regex("(^[a-z][a-z0-9-]{4,28}[a-z0-9]$|^$)", var.project_id))
+    error_message = "The project_id variable must be a valid GCP project ID. It must be 6 to 30 lowercase ASCII letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: tokyo-rain-123."
   }
 }
 


### PR DESCRIPTION
## Summary
This change fixes the regex that validates that users provide a valid project id, from
the Google documentation:
> The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited.

To breakdown the regex `^[a-z][a-z0-9-]{4,28}[a-z0-9]$|^$`:

- **1st Alternative `^[a-z][a-z0-9-]{4,28}[a-z0-9]$`**

  `^` asserts position at the start of a line
`a-z` matches a single character in the range between a and z (case sensitive) **[1st char]**
`[a-z0-9-]` Match a single character present in the list below **[2nd char]**
`a-z` matches a single character in the range between a and z (case sensitive)
`0-9` matches a single character in the range between 0 and 9 (case sensitive)
`-` matches the character `-` (case sensitive)
`{4,28}` matches the previous token between 4 and 28 times, as many times as possible, giving back as needed (greedy)**[6th to 29th char]**
`[a-z0-9]`Match a single character present in the list below **[30th char]**
`a-z` matches a single character in the range between a and z (case sensitive)
`0-9` matches a single character in the range between 0 and 9(case sensitive)
`$` asserts position at the end of a line

- **2nd Alternative `^$`**

  `^` asserts position at the start of a line
`$` asserts position at the end of a line **[empty string]**


## How did you test this change?

Used https://regex101.com/ 😏

## Issue

Related https://github.com/lacework/terraform-gcp-audit-log/pull/65
Closes https://github.com/lacework/terraform-gcp-config/issues/61
