### PR TITLE
fix: Folder onboarding depends on custom role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -150,7 +150,7 @@ resource "google_organization_iam_member" "lacework_custom_organization_role_bin
   role       = google_organization_iam_custom_role.lacework_custom_organization_role.0.name
   member     = "serviceAccount:${local.service_account_json_key.client_email}"
   depends_on = [google_organization_iam_custom_role.lacework_custom_organization_role]
-  count      = (local.resource_level == "ORGANIZATION" && !(local.exclude_folders || local.explicit_folders)) ? 1 : 0
+  count      = local.resource_level == "ORGANIZATION" ? 1 : 0
 }
 
 resource "google_organization_iam_member" "for_lacework_service_account" {


### PR DESCRIPTION
## Summary

I believe that, in order for our cfg-analyzers to work, we need to attach the custom role to the
service account that we will use to access the cloud resources.

After applying this change in my development environment, I can now see all my projects
inside the GCP folder I am onboarding.

## How did you test this change?

In our dev Google Cloud account, used this Terraform code:
```hcl
module "gitops_gcp_config" {
  source = "git::https://github.com/lacework/terraform-gcp-config.git?ref=main"

  providers = {
    google   = google.hipstershop
    lacework = lacework.gitops
  }

  org_integration = true
  organization_id = "1234512345"

  folders_to_include = [
    "folders/1234512345"
  ]

  lacework_integration_name = "TF Folder Onboarding"
}
```

After applying this plan, I used the CLI to list all GCP projects:
![Screen Shot 2022-07-28 at 8 45 06 AM](https://user-images.githubusercontent.com/5712253/181583054-8f3072b0-1d00-45c3-aad8-7dfc62020b1d.png)


## Issue

https://lacework.atlassian.net/browse/ALLY-837