### PR TITLE
fix: empty project_id to google_project data source

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   resource_level = var.org_integration ? "ORGANIZATION" : "PROJECT"
   resource_id    = var.org_integration ? var.organization_id : module.lacework_cfg_svc_account.project_id
-  project_id     = data.google_project.selected.project_id
+  project_id     = length(var.project_id) > 0 ? var.project_id : data.google_project.selected.project_id
 
   exclude_folders  = length(var.folders_to_exclude) != 0
   explicit_folders = length(var.folders_to_include) != 0
@@ -92,9 +92,7 @@ resource "random_id" "uniq" {
   byte_length = 4
 }
 
-data "google_project" "selected" {
-  project_id = var.project_id
-}
+data "google_project" "selected" {}
 
 module "lacework_cfg_svc_account" {
   source               = "lacework/service-account/gcp"


### PR DESCRIPTION

## Summary
A validation change https://github.com/hashicorp/terraform-provider-google/pull/12846
was introduced in version `4.42.0` of the google provider. This
validation makes all our GCP modules to fail with:
```
│ Error: "" project_id must be 6 to 30 with lowercase letters, digits, hyphens and start with a letter. Trailing hyphens are prohibited.
│
│   with module.gcp_project_config.data.google_project.selected,
│   on .terraform/modules/gcp_project_config/main.tf line 96, in data "google_project" "selected":
│   96:   project_id = var.project_id
```

To solve this issue we are avoiding using the `google_project` data
source when we know the `project_id` that was provided by the user.

If the user does not provide a `project_id`, then we use the data
source to discover the project from the google provider.

## How did you test this change?

Test should pass, plus we will test this in our private Terraform project https://github.com/lacework/terraform-customerdemo

## Issue

- https://lacework.atlassian.net/browse/RAIN-39458
- https://lacework.atlassian.net/browse/RAIN-37109