### PR TITLE
fix: avoid asking for project_id when is not needed

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   resource_level = var.org_integration ? "ORGANIZATION" : "PROJECT"
   resource_id    = var.org_integration ? var.organization_id : module.lacework_cfg_svc_account.project_id
-  project_id     = length(var.project_id) > 0 ? var.project_id : data.google_project.selected.project_id
+  project_id     = length(var.project_id) > 0 ? var.project_id : data.google_project.selected[0].project_id
 
   exclude_folders  = length(var.folders_to_exclude) != 0
   explicit_folders = length(var.folders_to_include) != 0
@@ -92,7 +92,9 @@ resource "random_id" "uniq" {
   byte_length = 4
 }
 
-data "google_project" "selected" {}
+data "google_project" "selected" {
+  count = length(var.project_id) > 0 ? 0 : 1
+}
 
 module "lacework_cfg_svc_account" {
   source               = "lacework/service-account/gcp"


### PR DESCRIPTION

## Summary

Avoid error message:
```
Error: no project value set. project_id must be set at the resource level, or a default project value must be specified on the provider
```


## Issue
https://lacework.atlassian.net/browse/LINK-1338
