### PR TITLE
Allows upgrading the google provider to 5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ essentialcontacts.googleapis.com
 | Name | Version |
 |------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 4.4.0, < 5.0.0 |
-| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | ~> 1.0 |
+| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | ~> 2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 | <a name="provider_time"></a> [time](#provider\_time) | ~> 0.6 |
 
@@ -121,4 +121,3 @@ essentialcontacts.googleapis.com
 |------|-------------|
 | <a name="output_service_account_name"></a> [service\_account\_name](#output\_service\_account\_name) | The Service Account name |
 | <a name="output_service_account_private_key"></a> [service\_account\_private\_key](#output\_service\_account\_private\_key) | The private key in JSON format, base64 encoded |
-<!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -121,3 +121,4 @@ essentialcontacts.googleapis.com
 |------|-------------|
 | <a name="output_service_account_name"></a> [service\_account\_name](#output\_service\_account\_name) | The Service Account name |
 | <a name="output_service_account_private_key"></a> [service\_account\_private\_key](#output\_service\_account\_private\_key) | The private key in JSON format, base64 encoded |
+<!-- END_TF_DOCS -->

--- a/main.tf
+++ b/main.tf
@@ -98,7 +98,7 @@ data "google_project" "selected" {
 
 module "lacework_cfg_svc_account" {
   source               = "lacework/service-account/gcp"
-  version              = "~> 1.0"
+  version              = "~> 2.0"
   create               = var.use_existing_service_account ? false : true
   service_account_name = local.service_account_name
   project_id           = local.project_id

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.14.0"
 
   required_providers {
-    google = "~> 5.6"
+    google = ">= 4.4.0"
     time   = "~> 0.6"
     lacework = {
       source  = "lacework/lacework"

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.14.0"
 
   required_providers {
-    google = ">= 4.4.0, < 5.0.0"
+    google = "~> 5.6"
     time   = "~> 0.6"
     lacework = {
       source  = "lacework/lacework"


### PR DESCRIPTION
## Summary

The google v5 provider is out since October 2023 and provides much needed features for us. But we can't upgrade to it because of lacework.

This allows lacework to work with google v5.x


## Related PRs

- https://github.com/lacework/terraform-gcp-config/pull/84
- https://github.com/lacework/terraform-gcp-audit-log/pull/87