### PR TITLE
fix: skip iam grants when using existing service account

### DIFF
--- a/examples/project-level-config-skip-iam-grants/README.md
+++ b/examples/project-level-config-skip-iam-grants/README.md
@@ -1,0 +1,63 @@
+## Skip IAM grants and use Existing Service Account at the Project Level
+
+This example shows how to skip iam grants and use an existing service account to create a Google Cloud Project integration with Lacework.
+
+The fields required for this example are:
+
+| Name                           | Description                                                                                  | Type |
+|--------------------------------|----------------------------------------------------------------------------------------------|------|
+| `use_existing_service_account` | Set this to `true` to use an existing service account.                                       | `bool` |
+| `skip_iam_grants`              | Set this to `true` to skip generation of custom role, and IAM grants to the Service Account. | `bool` |
+| `service_account_name`         | The name of an existing service account.                                                     | `string` |
+| `service_account_private_key`  | A private key from the existing service account in JSON format and base64 encoded            | `string` |
+
+```hcl
+provider "google" {}
+
+provider "lacework" {}
+
+module "gcp_project_level_config" {
+    source                       = "lacework/config/gcp"
+    project_id                   = var.project_id
+
+    use_existing_service_account = true
+    skip_iam_grants              = true
+    service_account_name         = "service_account_name"
+    service_account_private_key  = "service_account_key"
+}
+```
+
+Integration will fail if grants are not in place prior to execution. Make sure to create a custom role with the right 
+permissions shown in the [README.md#required-roles](https://github.com/lacework/terraform-gcp-config/blob/main/README.md#required-roles), and assign it to the existing service account. Example:
+
+```hcl
+locals {
+  default_project_roles = [
+    "roles/browser",
+    "roles/iam.securityReviewer",
+    "roles/cloudasset.viewer"
+  ]
+}
+
+resource "google_service_account" "lacework_gcp_compliance_config" {
+  account_id   = "lacework-sa-compliance"
+  description  = "Service account used by lacework for GCP compliance config"
+  display_name = "Lacework Compliance"
+  project      = var.project_id
+}
+
+resource "google_project_iam_member" "lacework_gcp_compliance_role" {
+  project = var.project_id
+  role    = "projects/${var.project_id}/roles/lacework.gcpCompliance" // already created custom role
+  member  = "serviceAccount:${google_service_account.lacework_gcp_compliance_config.email}"
+}
+
+resource "google_project_iam_member" "lacework_gcp_compliance_config_roles" {
+  for_each = toset(local.default_project_roles)
+  project  = var.project_id
+  role     = each.value
+  member  = "serviceAccount:${google_service_account.lacework_gcp_compliance_config.email}"
+}
+```
+
+For detailed information on integrating Lacework with Google Cloud see [GCP Compliance and Audit Trail Integration - Terraform From Any Supported Host](https://docs.lacework.com/gcp-compliance-and-audit-log-integration-terraform-from-any-supported-host)

--- a/examples/project-level-config-skip-iam-grants/main.tf
+++ b/examples/project-level-config-skip-iam-grants/main.tf
@@ -1,0 +1,35 @@
+provider "google" {}
+
+provider "lacework" {}
+
+module "gcp_project_level_config" {
+  source = "../../"
+
+  # Skip custom role creation
+  skip_iam_grants = true
+  # Provide an existing service account
+  use_existing_service_account = true
+  service_account_name         = google_service_account.lacework_gcp_compliance_config.name
+  service_account_private_key  = google_service_account_key.lacework_sa_compliance_key.private_key
+}
+
+resource "google_service_account" "lacework_gcp_compliance_config" {
+  account_id   = "lacework-sa-compliance"
+  description  = "Service account used by lacework for GCP compliance config"
+  display_name = "Lacework Compliance"
+  project      = var.project_id
+}
+
+resource "google_project_iam_member" "lacework_gcp_compliance_role" {
+  project = var.project_id
+  role    = "projects/${var.project_id}/roles/lacework.gcpCompliance" // already created custom role
+  member  = "serviceAccount:${google_service_account.lacework_gcp_compliance_config.email}"
+}
+
+resource "google_service_account_key" "lacework_sa_compliance_key" {
+  service_account_id = google_service_account.lacework_gcp_compliance_config.name
+}
+
+variable "project_id" {
+  default = "my-project-id"
+}

--- a/main.tf
+++ b/main.tf
@@ -124,7 +124,7 @@ resource "google_project_iam_member" "lacework_custom_project_role_binding" {
   role       = google_project_iam_custom_role.lacework_custom_project_role.0.name
   member     = "serviceAccount:${local.service_account_json_key.client_email}"
   depends_on = [google_project_iam_custom_role.lacework_custom_project_role]
-  count      = local.resource_level == "PROJECT" ? 1 : 0
+  count      = local.skip_iam_grants ? 0 : local.resource_level == "PROJECT" ? 1 : 0
 }
 
 resource "google_project_iam_member" "for_lacework_service_account" {

--- a/main.tf
+++ b/main.tf
@@ -124,7 +124,7 @@ resource "google_project_iam_member" "lacework_custom_project_role_binding" {
   role       = google_project_iam_custom_role.lacework_custom_project_role.0.name
   member     = "serviceAccount:${local.service_account_json_key.client_email}"
   depends_on = [google_project_iam_custom_role.lacework_custom_project_role]
-  count      = local.skip_iam_grants ? 0 : local.resource_level == "PROJECT" ? 1 : 0
+  count      = local.skip_iam_grants ? 0 : (local.resource_level == "PROJECT" ? 1 : 0)
 }
 
 resource "google_project_iam_member" "for_lacework_service_account" {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-gcp-config/blob/main/CONTRIBUTING.md
--->

## Summary
Using skip_iam_grants to skip custom role creation with use_existing_service_account fails. More details in the issue linked below.  
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?
Forked the module and tested the integration on my local setup. Created a custom role with necessary permissions, assigned it to the existing service account and applied the config. 

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

## Issue

https://github.com/lacework/terraform-gcp-config/issues/94

<!--
  Include the link to a Jira/Github issue
-->
