### PR TITLE
fix: use correct roles when folders_to_include is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,21 +82,23 @@ policyanalyzer.googleapis.com
 
 | Name | Type |
 |------|------|
-| [google_folder_iam_member.for_lacework_service_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/folder_iam_member) | resource |
-| [google_organization_iam_custom_role.lacework_custom_organization_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_custom_role) | resource |
-| [google_organization_iam_member.for_lacework_service_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_member) | resource |
-| [google_organization_iam_member.lacework_custom_organization_role_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_member) | resource |
-| [google_project_iam_custom_role.lacework_custom_project_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
-| [google_project_iam_member.for_lacework_service_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.for_lacework_service_account_root_projects](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.lacework_custom_project_role_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_folder_iam_member.lacework_folder_custom_role_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/folder_iam_member) | resource |
+| [google_folder_iam_member.lacework_folder_roles_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/folder_iam_member) | resource |
+| [google_organization_iam_custom_role.lacework_organization_custom_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_custom_role) | resource |
+| [google_organization_iam_member.lacework_organization_custom_role_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_member) | resource |
+| [google_organization_iam_member.lacework_organization_roles_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_member) | resource |
+| [google_project_iam_custom_role.lacework_project_custom_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
+| [google_project_iam_member.lacework_project_custom_role_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.lacework_project_roles_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.lacework_root_project_custom_role_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.lacework_root_project_roles_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_service.required_apis](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
 | [lacework_integration_gcp_cfg.default](https://registry.terraform.io/providers/lacework/lacework/latest/docs/resources/integration_gcp_cfg) | resource |
 | [random_id.uniq](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [time_sleep.wait_time](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
-| [google_folders.my-org-folders](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/folders) | data source |
+| [google_folders.org_folders](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/folders) | data source |
 | [google_project.selected](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
-| [google_projects.my-org-projects](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/projects) | data source |
+| [google_projects.org_projects](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/projects) | data source |
 | [lacework_metric_module.lwmetrics](https://registry.terraform.io/providers/lacework/lacework/latest/docs/data-sources/metric_module) | data source |
 
 ## Inputs

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,8 @@
 locals {
-  resource_level = var.org_integration ? "ORGANIZATION" : "PROJECT"
-  resource_id    = var.org_integration ? var.organization_id : module.lacework_cfg_svc_account.project_id
-  project_id     = length(var.project_id) > 0 ? var.project_id : data.google_project.selected[0].project_id
+  project_id = length(var.project_id) > 0 ? var.project_id : data.google_project.selected[0].project_id
 
-  exclude_folders  = length(var.folders_to_exclude) != 0
-  explicit_folders = length(var.folders_to_include) != 0
+  exclude_folders = length(var.folders_to_exclude) != 0
+  include_folders = length(var.folders_to_include) != 0
 
   service_account_name = var.use_existing_service_account ? (
     var.service_account_name
@@ -20,75 +18,33 @@ locals {
 
   skip_iam_grants = var.use_existing_service_account && var.skip_iam_grants
 
-  default_project_roles = local.skip_iam_grants ? [] : [
+  default_roles = [
     "roles/browser",
     "roles/iam.securityReviewer",
     "roles/cloudasset.viewer",
     "roles/policyanalyzer.activityAnalysisViewer"
   ]
 
-  default_organization_roles = local.skip_iam_grants ? [] : [
-    "roles/browser",
-    "roles/iam.securityReviewer",
-    "roles/cloudasset.viewer",
-    "roles/policyanalyzer.activityAnalysisViewer"
+  custom_role_permissions = [
+    "bigquery.datasets.get",
+    "compute.projects.get",
+    "pubsub.topics.get",
+    "storage.buckets.get",
+    "compute.sslPolicies.get"
   ]
 
-  // if org_integration is false, project_roles = local.default_project_roles
-  project_roles = var.org_integration ? [] : local.default_project_roles
+  folders = var.org_integration ? (
+    local.exclude_folders ? setsubtract(data.google_folders.org_folders[0].folders[*].name, var.folders_to_exclude) :
+    local.include_folders ? var.folders_to_include : []
+  ) : []
 
-  // if org_integration is true, organization_roles = local.default_organization_roles
-  organization_roles = local.skip_iam_grants ? [] : (
-    (var.org_integration && !(local.exclude_folders || local.explicit_folders)) ? (
-      local.default_organization_roles
-      ) : (
-      (var.org_integration && (local.exclude_folders || local.explicit_folders)) ? (
-        ["roles/resourcemanager.organizationViewer"]
-        ) : (
-        []
-      )
-    )
-  )
+  root_projects = (var.org_integration && local.exclude_folders && var.include_root_projects) ? (
+    data.google_projects.org_projects[0].projects[*].project_id
+  ) : []
 
-  default_folder_roles = local.skip_iam_grants ? [] : (
-    (var.org_integration && (local.exclude_folders || local.explicit_folders)) ? (
-      [
-        "roles/browser",
-        "roles/iam.securityReviewer",
-        "roles/cloudasset.viewer",
-        "roles/policyanalyzer.activityAnalysisViewer",
-        google_organization_iam_custom_role.lacework_custom_organization_role.0.name
-      ]
-      ) : (
-      []
-    )
-  )
+  folder_roles_product = tolist(setproduct(local.folders, local.default_roles))
 
-  folders = [
-    (var.org_integration && local.exclude_folders) ? (
-      setsubtract(data.google_folders.my-org-folders[0].folders[*].name, var.folders_to_exclude)
-      ) : (
-      var.org_integration && local.explicit_folders) ? (
-      var.folders_to_include
-      ) : (
-      toset([])
-  )]
-
-  root_projects = [
-    (var.org_integration && local.exclude_folders && var.include_root_projects) ? toset(data.google_projects.my-org-projects[0].projects[*].project_id) : toset([])
-  ]
-
-  folder_roles = (var.org_integration && (local.exclude_folders || local.explicit_folders)) ? (
-    setproduct(local.folders[0][*], local.default_folder_roles)
-    ) : (
-    []
-  )
-
-  root_project_roles = (var.org_integration && var.include_root_projects) ? (
-    setproduct(local.root_projects[0][*], local.default_folder_roles)
-    ) : (
-    []
-  )
+  root_project_roles_product = tolist(setproduct(local.root_projects, local.default_roles))
 
   version_file   = "${abspath(path.module)}/VERSION"
   module_name    = "terraform-gcp-config"
@@ -111,79 +67,93 @@ module "lacework_cfg_svc_account" {
   project_id           = local.project_id
 }
 
-// Roles for a PROJECT level integration
-resource "google_project_iam_custom_role" "lacework_custom_project_role" {
+resource "google_project_iam_custom_role" "lacework_project_custom_role" {
+  count       = (!local.skip_iam_grants && !var.org_integration) ? 1 : 0
   project     = local.project_id
   role_id     = "lwComplianceRole_${random_id.uniq.hex}"
   title       = "Lacework Compliance Role"
   description = "Lacework Compliance Role"
-  permissions = ["bigquery.datasets.get", "compute.projects.get", "pubsub.topics.get", "storage.buckets.get", "compute.sslPolicies.get"]
-  count       = local.skip_iam_grants ? 0 : (local.resource_level == "PROJECT" ? 1 : 0)
+  permissions = local.custom_role_permissions
 }
 
-
-resource "google_project_iam_member" "lacework_custom_project_role_binding" {
+resource "google_project_iam_member" "lacework_project_custom_role_binding" {
+  count      = (!local.skip_iam_grants && !var.org_integration) ? 1 : 0
   project    = local.project_id
-  role       = google_project_iam_custom_role.lacework_custom_project_role.0.name
+  role       = google_project_iam_custom_role.lacework_project_custom_role.0.name
   member     = "serviceAccount:${local.service_account_json_key.client_email}"
-  depends_on = [google_project_iam_custom_role.lacework_custom_project_role]
-  count      = local.resource_level == "PROJECT" ? 1 : 0
+  depends_on = [google_project_iam_custom_role.lacework_project_custom_role]
 }
 
-resource "google_project_iam_member" "for_lacework_service_account" {
-  for_each = toset(local.project_roles)
-  project  = local.project_id
-  role     = each.value
-  member   = "serviceAccount:${local.service_account_json_key.client_email}"
+resource "google_project_iam_member" "lacework_project_roles_binding" {
+  for_each   = toset((!local.skip_iam_grants && !var.org_integration) ? local.default_roles : [])
+  project    = local.project_id
+  role       = each.value
+  member     = "serviceAccount:${local.service_account_json_key.client_email}"
+  depends_on = [google_project_iam_custom_role.lacework_project_custom_role]
 }
 
-// Roles for an ORGANIZATION level integration
-
-data "google_folders" "my-org-folders" {
+data "google_folders" "org_folders" {
   count     = (var.org_integration && local.exclude_folders) ? 1 : 0
   parent_id = "organizations/${var.organization_id}"
 }
 
-data "google_projects" "my-org-projects" {
+data "google_projects" "org_projects" {
   count  = (local.exclude_folders && var.include_root_projects) ? 1 : 0
   filter = "parent.id=${var.organization_id}"
 }
 
-resource "google_organization_iam_custom_role" "lacework_custom_organization_role" {
+resource "google_organization_iam_custom_role" "lacework_organization_custom_role" {
+  count       = (!local.skip_iam_grants && var.org_integration) ? 1 : 0
   role_id     = "lwOrgComplianceRole_${random_id.uniq.hex}"
   org_id      = var.organization_id
   title       = "Lacework Org Compliance Role"
   description = "Lacework Org Compliance Role"
-  permissions = ["bigquery.datasets.get", "compute.projects.get", "pubsub.topics.get", "storage.buckets.get", "compute.sslPolicies.get"]
-  count       = local.skip_iam_grants ? 0 : (local.resource_level == "ORGANIZATION" ? 1 : 0)
+  permissions = local.custom_role_permissions
 }
 
-resource "google_organization_iam_member" "lacework_custom_organization_role_binding" {
+resource "google_organization_iam_member" "lacework_organization_custom_role_binding" {
+  count      = (!local.skip_iam_grants && var.org_integration) ? 1 : 0
   org_id     = var.organization_id
-  role       = google_organization_iam_custom_role.lacework_custom_organization_role.0.name
+  role       = google_organization_iam_custom_role.lacework_organization_custom_role.0.name
   member     = "serviceAccount:${local.service_account_json_key.client_email}"
-  depends_on = [google_organization_iam_custom_role.lacework_custom_organization_role]
-  count      = local.skip_iam_grants ? 0 : (local.resource_level == "ORGANIZATION" ? 1 : 0)
+  depends_on = [google_organization_iam_custom_role.lacework_organization_custom_role]
 }
 
-resource "google_organization_iam_member" "for_lacework_service_account" {
-  for_each = toset(local.organization_roles)
-  org_id   = var.organization_id
-  role     = each.value
+resource "google_organization_iam_member" "lacework_organization_roles_binding" {
+  for_each   = toset((!local.skip_iam_grants && var.org_integration) ? local.default_roles : [])
+  org_id     = var.organization_id
+  role       = each.value
+  member     = "serviceAccount:${local.service_account_json_key.client_email}"
+  depends_on = [google_organization_iam_custom_role.lacework_organization_custom_role]
+}
+
+resource "google_folder_iam_member" "lacework_folder_custom_role_binding" {
+  for_each   = toset(!local.skip_iam_grants ? local.folders : [])
+  folder     = each.value
+  role       = google_organization_iam_custom_role.lacework_organization_custom_role.0.name
+  member     = "serviceAccount:${local.service_account_json_key.client_email}"
+  depends_on = [google_organization_iam_custom_role.lacework_organization_custom_role]
+}
+
+resource "google_folder_iam_member" "lacework_folder_roles_binding" {
+  count      = !local.skip_iam_grants ? length(local.folder_roles_product) : 0
+  folder     = local.folder_roles_product[count.index][0]
+  role       = local.folder_roles_product[count.index][1]
+  member     = "serviceAccount:${local.service_account_json_key.client_email}"
+  depends_on = [google_organization_iam_custom_role.lacework_organization_custom_role]
+}
+
+resource "google_project_iam_member" "lacework_root_project_custom_role_binding" {
+  for_each = toset(!local.skip_iam_grants ? local.root_projects : [])
+  project  = each.value
+  role     = google_organization_iam_custom_role.lacework_organization_custom_role.0.name
   member   = "serviceAccount:${local.service_account_json_key.client_email}"
 }
 
-resource "google_folder_iam_member" "for_lacework_service_account" {
-  count  = length(local.folder_roles)
-  folder = local.folder_roles[count.index][0]
-  role   = local.folder_roles[count.index][1]
-  member = "serviceAccount:${local.service_account_json_key.client_email}"
-}
-
-resource "google_project_iam_member" "for_lacework_service_account_root_projects" {
-  count   = length(local.root_project_roles)
-  project = local.root_project_roles[count.index][0]
-  role    = local.root_project_roles[count.index][1]
+resource "google_project_iam_member" "lacework_root_project_roles_binding" {
+  count   = !local.skip_iam_grants ? length(local.root_project_roles_product) : 0
+  project = local.root_project_roles_product[count.index][0]
+  role    = local.root_project_roles_product[count.index][1]
   member  = "serviceAccount:${local.service_account_json_key.client_email}"
 }
 
@@ -202,15 +172,21 @@ resource "time_sleep" "wait_time" {
   depends_on = [
     module.lacework_cfg_svc_account,
     google_project_service.required_apis,
-    google_organization_iam_member.for_lacework_service_account,
-    google_project_iam_member.for_lacework_service_account
+    google_organization_iam_member.lacework_organization_custom_role_binding,
+    google_organization_iam_member.lacework_organization_roles_binding,
+    google_project_iam_member.lacework_project_custom_role_binding,
+    google_project_iam_member.lacework_project_roles_binding,
+    google_folder_iam_member.lacework_folder_custom_role_binding,
+    google_folder_iam_member.lacework_folder_roles_binding,
+    google_project_iam_member.lacework_root_project_custom_role_binding,
+    google_project_iam_member.lacework_root_project_roles_binding
   ]
 }
 
 resource "lacework_integration_gcp_cfg" "default" {
   name           = var.lacework_integration_name
-  resource_id    = local.resource_id
-  resource_level = local.resource_level
+  resource_id    = var.org_integration ? var.organization_id : module.lacework_cfg_svc_account.project_id
+  resource_level = var.org_integration ? "ORGANIZATION" : "PROJECT"
   credentials {
     client_id      = local.service_account_json_key.client_id
     private_key_id = local.service_account_json_key.private_key_id


### PR DESCRIPTION
## Summary

- Fix roles when `folders_to_include` is set
- Remove `roles/resourcemanager.organizationViewer`. It's permission is already covered by `roles/browse`
- Add dependencies for `lacework_integration_gcp_cfg`
- Clean up code

## How did you test this change?

Run 
```
provider "google" {}

provider "lacework" {}

module "gcp_organization_level_config" {
  source = "../../"

  org_integration = true
  organization_id = "121868925203"
  project_id      = "abc-demo-project-123"

  folders_to_exclude = ["folders/561670468574"]
}
```

Integration completes successfully:

<img width="1037" alt="Screenshot 2025-04-03 at 8 09 58 PM" src="https://github.com/user-attachments/assets/f893ab55-0fa4-4e77-94be-360239d46cf0" />
